### PR TITLE
Code of conduct

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^pkgdown$
 ^\.github$
 ^cran-comments\.md$
+^CODE_OF_CONDUCT.md$


### PR DESCRIPTION
Prevents:

```r
❯ checking top-level files ... NOTE
  Non-standard file/directory found at top level:
    ‘CODE_OF_CONDUCT.md’
```
when running `check()`