### PR TITLE
extract references from yaml header into separate, centralized file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Description: Translates antibody levels measured in a cross-sectional population
 Depends: R (>= 2.10)
 License: GPL-3
 Imports: 
+    bookdown,
     dplyr,
     Rcpp,
     stats,

--- a/references.bib
+++ b/references.bib
@@ -1,0 +1,68 @@
+@article{de_Graaf_2014,
+	doi = {10.1016/j.epidem.2014.08.002},
+	url = {https://doi.org/10.1016%2Fj.epidem.2014.08.002},
+	year = 2014,
+	month = {dec},
+	publisher = {Elsevier {BV}},
+	volume = {9},
+	pages = {1--7},
+	author = {W.F. de Graaf and M.E.E. Kretzschmar and P.F.M. Teunis and O. Diekmann},
+	title = {A two-phase within-host model for immune response and its application to serological profiles of pertussis},
+	journal = {Epidemics}
+}
+
+@article{Simonsen_2009,
+	doi = {10.1002/sim.3592},
+	url = {https://doi.org/10.1002%2Fsim.3592},
+	year = 2009,
+	month = {jun},
+	publisher = {Wiley},
+	volume = {28},
+	number = {14},
+	pages = {1882--1895},
+	author = {J. Simonsen and K. M{\o}lbak and G. Falkenhorst and K. A. Krogfelt and A. Linneberg and P. F. M. Teunis},
+	title = {Estimation of incidences of infectious diseases based on antibody measurements},
+	journal = {Statistics in Medicine}
+}
+
+@article{Teunis_2012,
+	doi = {10.1002/sim.5322},
+	url = {https://doi.org/10.1002%2Fsim.5322},
+	year = 2012,
+	month = {mar},
+	publisher = {Wiley},
+	volume = {31},
+	number = {20},
+	pages = {2240--2248},
+	author = {PFM Teunis and JCH van Eijkeren and CW Ang and YTHP van Duynhoven and JB Simonsen and MA Strid and W van Pelt},
+	title = {Biomarker dynamics: estimating infection rates from serological data},
+	journal = {Statistics in Medicine}
+}
+
+@article{Teunis_2016,
+	doi = {10.1016/j.epidem.2016.04.001},
+	url = {https://doi.org/10.1016%2Fj.epidem.2016.04.001},
+	year = 2016,
+	month = {sep},
+	publisher = {Elsevier {BV}},
+	volume = {16},
+	pages = {33--39},
+	author = {P.F.M. Teunis and J.C.H. van Eijkeren and W.F. de Graaf and A. Bona{\v{c}}i{\'{c}} Marinovi{\'{c}} and M.E.E. Kretzschmar},
+	title = {Linking the seroresponse to infection to within-host heterogeneity in antibody production},
+	journal = {Epidemics}
+}
+
+@article{Strid_2001,
+	doi = {10.1128/cdli.8.2.314-319.2001},
+	url = {https://doi.org/10.1128%2Fcdli.8.2.314-319.2001},
+	year = 2001,
+	month = {mar},
+	publisher = {American Society for Microbiology},
+	volume = {8},
+	number = {2},
+	pages = {314--319},
+	author = {Mette Aagaard Strid and J{\o}rgen Engberg and Lena Brandt Larsen and Kamilla Begtrup and K{\aa}re M{\o}lbak and Karen Angeliki Krogfelt},
+	title = {Antibody responses to Campylobacter infections determined by an enzyme-linked immunosorbent assay: 2-year follow-up study of 210 patients},
+	journal = {Clinical Diagnostic Laboratory Immunology}
+}
+

--- a/vignettes/tutorial.Rmd
+++ b/vignettes/tutorial.Rmd
@@ -2,7 +2,9 @@
 title: "Serocalculator package tutorial"
 author: "UC Davis SeroEpidemiology Group"
 date: "`r Sys.Date()`"
-output: rmarkdown::html_vignette
+output: 
+  rmarkdown::html_vignette:
+    toc: yes
 header-includes: "\\DeclareUnicodeCharacter{2010}{-}"
 bibliography: ../references.bib
 fontsize: 11pt

--- a/vignettes/tutorial.Rmd
+++ b/vignettes/tutorial.Rmd
@@ -2,132 +2,9 @@
 title: "Serocalculator package tutorial"
 author: "UC Davis SeroEpidemiology Group"
 date: "`r Sys.Date()`"
-output:
-  rmarkdown::html_vignette:
-    toc: yes
-  html_document:
-    toc: yes
-    df_print: paged
-  pdf_document:
-    toc: yes
+output: rmarkdown::html_vignette
 header-includes: "\\DeclareUnicodeCharacter{2010}{-}"
-references:
-- id: 1
-  author:
-  - family: de Graaf
-    given: W. F.
-  - family: Kretzschmar
-    given: M. E. E.
-  - family: Teunis
-    given: P. F. M.
-  - family: Diekmann
-    given: O.
-  container-title: Epidemics
-  DOI: 10.1016/j.epidem.2014.08.002
-  issued:
-    month: 12
-    year: 2014
-  page: "1-7"
-  title: "A two-phase within-host model for immune response and its application to
-    serological profiles of pertussis"
-  type: "article-journal"
-  volume: 9
-- id: 2
-  author:
-  - family: Simonsen
-    given: J.
-  - family: Mølbak
-    given: K.
-  - family: Falkenhorst
-    given: G.
-  - family: Krogfelt
-    given: K. A.
-  - family: Linneberg
-    given: A.
-  - family: Teunis
-    given: P. F.
-  container-title: Statistics in Medicine
-  DOI: 10.1002/sim.3592
-  issue: 14
-  issued:
-    month: 6
-    year: 2009
-  page: "1882-1895"
-  title: Estimation of incidences of infectious diseases based on antibody measurements
-  type: "article-journal"
-  volume: 28
-- id: 3
-  author:
-  - family: Teunis
-    given: P. F.
-  - family: van Eijkeren
-    given: J. C.
-  - family: Ang
-    given: C. W.
-  - family: van Duynhoven
-    given: Y. T.
-  - family: Simonsen
-    given: J. B.
-  - family: Strid
-    given: M. A.
-  - family: van Pelt
-    given: W.
-  container-title: Statistics in Medicine
-  DOI: 10.1002/sim.5322
-  issue: 208
-  issued:
-    month: 9
-    year: 2012
-    page: "2240-2248"
-  title: 'Biomarker dynamics: estimating infection rates from serological data'
-  type: "article-journal"
-  volume: 31
-- id: 4
-  author:
-  - family: Teunis
-    given: P. F.
-  - family: van Eijkeren
-    given: J. C.
-  - family: de Graaf
-    given: W. F.
-  - family: Bonačić Marinović
-    given: A.
-  - family: Kretzschmar
-    given: M. E. E.
-  container-title: Epidemics
-  DOI: 10.1016/j.epidem.2016.04.001
-  issued:
-    month: 9
-    year: 2016
-    page: "33-39"
-  title: "Linking the seroresponse to infection to within-host heterogeneity in antibody
-    production"
-  type: "article-journal"
-  volume: 16
-- id: 5
-  author:
-  - family: Strid
-    given: M. A.
-  - family: Engberg
-    given: J.
-  - family: Larsen,
-    given: L. B.
-  - family: Begtrup
-    given: K
-  - family: Mølbak
-    given: K
-  - family: Krogfelt
-    given: K. A.
-  title: "Antibody responses to Campylobacter infections determined by an enzyme--linked
-    immunosorbent assay: 2-year follow-up study of 210 patients"
-  container-title: Clinical and Vaccine Immunology
-  issue: 8
-  volume: 2
-  page: "314-319"
-  issued:
-    year: 2001
-    month: 3
-  DOI: "10.1128/CDLI.8.2.314-319.2001"
+bibliography: ../references.bib
 fontsize: 11pt
 vignette: > 
   %\VignetteIndexEntry{Serocalculator package tutorial}    
@@ -148,7 +25,7 @@ pkgUrl <- gsub("\n", "", packageDescription(pkgName)$URL)
 
 \newpage
 
-# 1. Introduction
+# Introduction
 
 Antibody levels measured in a (cross–sectional) population sample can be translated into an estimate 
 of the frequency with which seroconversions (infections) occur in the sampled population. In simple 
@@ -184,7 +61,7 @@ presumably describing a physiological phenomenon that is similiar in any infecte
 (3) setting up and running the longitudinal model requires additional skills, not necessary for use 
 of the sero–incidence calculator script
 
-# 2. The seroincidence estimator
+# The seroincidence estimator
 
 Package **serocalculator** was designed to calculate incidence of seroconversion, by using the 
 longitudinal seroresponse characteristics. The distribution of serum antibody concentrations in a 
@@ -193,7 +70,7 @@ and the frequency of seroconversion (or seroincidence). Given the seroresponse, 
 distribution of antibody concentrations can be fitted to the cross-sectional data, by adjusting the 
 seroconversion frequency, thus providing a means to estimate the seroconversion frequency.
 
-## 2.1 Time course of serum antibodies
+## Time course of serum antibodies
 
 The seroresponse, the time course of serum antibodies following seroconversion (infection) is 
 described by means of a set of parameters describing it. These parameters may include:
@@ -203,9 +80,9 @@ b) time to reach peak antibody concentration,
 c) magnitude of the peak concentration, and 
 d) antibody decay parameters describing the time course (shape and rate) of antibody decay. 
 
-A model description that is used for the serocalculator is described in [@2; @3]. An alternative 
+A model description that is used for the serocalculator is described in [@Simonsen_2009; @Teunis_2012]. An alternative 
 model, simplified but with improved interpretation of the underlying biological mechanisms, is given 
-in [@1] and further improved in [@4]. 
+in [@de_Graaf_2014] and further improved in [@Teunis_2016]. 
 
 The current model assumes that upon exposure to an initial inoculum, pathogen concentrations 
 increase exponentially. Presence of pathogens (antigen presented to the immune system) signals an 
@@ -215,10 +92,10 @@ causes inactivation or die–off of pathogens, with a rate proportional to the s
 concentration. Ultimately, when all pathogens are removed, infection is over and the promotion of 
 antibody production stops. Then the decay phase starts, and serum antibody concentrations decrease. 
 Antibody decay in the serum compartment may start fast and slow down later, resulting in 
-non–exponential decay. In [@4] this is modelled using a shape parameter, allowing gradual adjustment 
+non–exponential decay. In [@Teunis_2016] this is modelled using a shape parameter, allowing gradual adjustment 
 between exponential (log–linear) and strongly non–exponential decay.
 
-## 2.2 Heterogenity
+## Heterogenity
 
 The five parameters describing the seroresponse (in round brackets names of corresponding 
 parameters used in the package, see [section 3.2.2](#longParams) for details): baseline antibody 
@@ -237,21 +114,21 @@ decay curve.
 
 A Bayesian hierarchical framework allows for individual variation in seroresponses, so that one 
 obtains the (posterior) joint distribution of the parameters as a (Markov chain) Monte Carlo sample, 
-of all relevant parameters [@4].
+of all relevant parameters [@Teunis_2016].
 
 Note that, due to the limited number of iterations in the Monte Carlo sample, the generated 
 incidence estimates will show minor variations: if the same calculation is run twice, the outcomes 
 may differ slightly. If this variation should be smaller, the size of the Monte Carlo sample may be 
 increased. This however will slow down the calculations.
 
-## 2.3 Incidence estimation
+## Incidence estimation
 
 The longitudinal seroresponses are considered generic: they represent the time course of (specific) 
 human serum antibodies against a (specific) pathogen. Therefore, with any cross–sectional sample of 
 the same antibodies in a human population, an incidence estimate can be calculated. 
 
 Given the longitudinal response characteristics, **serocalculator** R package provide a rapid and 
-computationally simple method for calculating seroconversion rates, as published in [@3].
+computationally simple method for calculating seroconversion rates, as published in [@Teunis_2012].
 
 The methods on which the seroincidence calculator is based were developed with publicly funded 
 research. All procedures have been published and are open to the general public, including the core 
@@ -259,12 +136,13 @@ script on which the seroincidence calculator is based. To make the functionaliti
 broadly available as possible, R was chosen as the computing platform, because it is free and open 
 source, and runs on any modern computer operating system.
 
-## 2.4 Model variants
+## Model variants
 
 The package contains longitudinal models for seroincidence calculations. Four model variants are 
 possible, depending on whether seroconversion is instantaneous ($t_{1} = 0$) or not ($t_{1} > 0$), 
 and whether decay is exponential ($r = 1$) or proceeds as a power function ($r > 1$). Power function 
-decay allows for rapid inital decay followed by a sustained period of very slow decay [@4]. 
+decay allows for rapid inital decay followed by a sustained period of very slow decay [@Teunis_2016]. 
+
 Available model variants are described in Table 1.
 
 \begin{table}[!h]
@@ -297,11 +175,11 @@ Pathogen & Antibody & Units & 1 & 2 & 3 & 4\\ \hline
 \end{footnotesize}
 \end{table}
 
-# 3. How to use *serocalculator* package
+# How to use *serocalculator* package
 
 This section provides step-by-step directions on the usage of the *serocalculator* package.
 
-## 3.1. Loading the package
+## Loading the package
 
 Functionality of the *serocalculator* package is made available to the end user only once the library 
 is loaded into the current workspace. Assuming the package is installed already (covered in 
@@ -341,7 +219,7 @@ parameters from an online repository. Files available for download are `coxiella
 d) `estimateSeroincidence`: Main function of the package. Estimates seroincidence based on supplied 
 cross-section antibody levels data and longitudinal response parameters. Object class: `function`.
 
-## 3.2. Specifying input data
+## Specifying input data
 
 There are two sets of inputs to the serology calculator that must always be specified:
 
@@ -352,7 +230,7 @@ b) Longitudinal response characteristic as set of parameters `(y1, alpha, yb, r,
 
 We start with loading antibody levels measured in cross-sectional population sample.
 
-### 3.2.1. Specifying cross-sectional antibody levels data
+### Specifying cross-sectional antibody levels data
 
 The user has a few options of providing this data to the calculator:
 
@@ -418,7 +296,7 @@ Then it can be loaded into R like this:
 serologyData <- read.csv(file = "C:\\cross-sectional-data.csv")
 ```
 
-### 3.2.2. Specifying longitudinal response parameters {#longParams}
+### Specifying longitudinal response parameters {#longParams}
 
 The longitudinal response parameters set consists of the following items:
 
@@ -493,7 +371,7 @@ responseParams <- getAdditionalData("coxiellaIFAParams4.zip")
 
 Internet connection is needed for this function to work.
 
-## 3.3. Estimating seroincidence
+## Estimating seroincidence
 
 Main calculation function provided by package *serocalculator* is called `estimateSeroincidence`.
 It takes several arguments:
@@ -581,7 +459,7 @@ The most important output is subobject `Fits` containing raw results on the outp
 Translation of these raw results is provided by a custom function `summary` explained in the 
 following section.
 
-The cutoff argument is based on censoring of the observed serum antibody measurements [@5]. Cut-off 
+The cutoff argument is based on censoring of the observed serum antibody measurements [@Strid_2001]. Cut-off 
 levels must always be specified when calling function `estimateSeroincidence` (argument 
 `censorLimits`). Value `0` should be set for antibody measurements where no censoring is needed, for 
 instance 
@@ -595,7 +473,7 @@ estimates of lambda to decrease. Results should be published together with the c
 values. The cut-off level of `0.1` set in the example above is a typical value, but users should set 
 it to value reflecting the censoring level in the data.
 
-## 3.4. Getting a summary of seroincidence
+## Getting a summary of seroincidence
 
 Output of the calculator should be passed in to function `summary` calculating output results:
 
@@ -669,7 +547,7 @@ seroincidenceSummary$Results
 As one may note it is a dataframe with six columns that can be later post-processed with custom 
 calculations.
 
-# 4. Other examples
+# Other examples
 
 The following examples show the standard procedure for estimating seroincidence.
 

--- a/vignettes/tutorial.Rmd
+++ b/vignettes/tutorial.Rmd
@@ -5,6 +5,7 @@ date: "`r Sys.Date()`"
 output: 
   rmarkdown::html_vignette:
     toc: yes
+    number_sections: true
 header-includes: "\\DeclareUnicodeCharacter{2010}{-}"
 bibliography: ../references.bib
 fontsize: 11pt


### PR DESCRIPTION
I'm starting to clean up the `tutorial.Rmd` file; here I extracted the article references from the header into a separate file. @kristinawlai, please take a look at what I've done here; we'll want to do the same thing other places as well.

I also removed the handwritten section numbers; it's more sustainable to have Rmarkdown number them for us.