### PR TITLE
require dplyr version 1.1.1 or higher, to use the `relationship` argu…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: Translates antibody levels measured in cross-sectional population
 Depends: R (>= 3.5.0)
 License: GPL-3
 Imports: 
-    dplyr,
+    dplyr (>= 1.1.1),
     magrittr,
     parallel,
     Rcpp,


### PR DESCRIPTION
Adding a version requirement for `dplyr`, so we can use the `relationship` argument in `inner_join()`.

c.f.:
https://r-pkgs.org/description.html#sec-description-imports-suggests-minium-version