### PR TITLE
Move methods + final fixes

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 
 Antibody levels measured in a cross–sectional population sample can be translated into an estimate of the frequency with which seroconversions (infections) occur in the sampled population. In other words, the presence of many high antibody titers indicates that many individuals likely experienced infection recently and the burden of disease is high in the population, while low titers indicate a low frequency of infections in the sampled population and therefore a lower burden of disease.
 
-The **serocalculator** package was designed to use the longitudinal response characteristics using a set of modeled parameters characterizing the longitudinal response of the selected serum antibodies. More details on the underlying methods can be found in `vignette("serocalculator")` or the "Getting Started" link above.
+The **serocalculator** package was designed to use the longitudinal response characteristics using a set of modeled parameters characterizing the longitudinal response of the selected serum antibodies. More details on the underlying methods can be found in `vignette("serocalculator")` or [Getting Started](https://ucd-serg.github.io/serocalculator/articles/serocalculator.html).
 
 
 ## Installing R

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 
 Antibody levels measured in a cross–sectional population sample can be translated into an estimate of the frequency with which seroconversions (infections) occur in the sampled population. In other words, the presence of many high antibody titers indicates that many individuals likely experienced infection recently and the burden of disease is high in the population, while low titers indicate a low frequency of infections in the sampled population and therefore a lower burden of disease.
 
-The **serocalculator** package was designed to use the longitudinal response characteristics using a set of modeled parameters characterizing the longitudinal response of the selected serum antibodies. More details on the underlying methods can be found in `vignette("serocalculator")` or [Getting Started](https://ucd-serg.github.io/serocalculator/articles/serocalculator.html).
+The **serocalculator** package was designed to use the longitudinal response characteristics using a set of modeled parameters characterizing the longitudinal response of the selected serum antibodies. More details on the underlying methods can be found in [Getting Started](https://ucd-serg.github.io/serocalculator/articles/serocalculator.html).
 
 
 ## Installing R

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,22 +24,8 @@ knitr::opts_chunk$set(
 
 Antibody levels measured in a cross–sectional population sample can be translated into an estimate of the frequency with which seroconversions (infections) occur in the sampled population. In other words, the presence of many high antibody titers indicates that many individuals likely experienced infection recently and the burden of disease is high in the population, while low titers indicate a low frequency of infections in the sampled population and therefore a lower burden of disease.
 
-The **serocalculator** package was designed to use the longitudinal response characteristics using a set of modeled parameters characterizing the longitudinal response of the selected serum antibodies. 
+The **serocalculator** package was designed to use the longitudinal response characteristics using a set of modeled parameters characterizing the longitudinal response of the selected serum antibodies. More details on the underlying methods can be found in `vignette("serocalculator")` or the "Getting Started" link above.
 
-## Methods
-
-The **serocalculator** R package provides a rapid and computationally simple method for calculating seroconversion rates, as originally published in @Simonsen_2009 and @Teunis_2012, and further developed in subsequent publications by @de_Graaf_2014, @Teunis_2016, and @Teunis_2020. In short, longitudinal seroresponses from confirmed cases with a known symptom onset date are assumed to represent the time course of human serum antibodies against a specific pathogen. Therefore, by using these longitudinal antibody dynamics with any cross–sectional sample of the same antibodies in a human population, an incidence estimate can be calculated. Further details are below.
-
-### A Proxy for Infection 
- 
-While the exact time of infection is impossible to measure in an individual, antibody levels measured in a cross–sectional population sample can be translated into an estimate of the frequency with which seroconversions (infections) occur in the sampled population. So the presence of many high antibody concentrations indicates that many people in the population likely experienced infection recently, while mostly low concentrations indicate a low frequency of infections in the sampled population.
-
-
-In order to interpret the measured cross-sectional antibody concentrations in terms of incidence, we must define the antibody dynamic over time to understand the generalized antibody response at different times since infection. This dynamic must be quantified over time to include an initial increase in serum antibody concentration when seroconversion occurs, followed by a gradual decrease as antibodies wane. In published studies, this information on the time course of the serum antibody response has been obtained from longitudinal follow–up data in cases who had a symptomatic episode following infection. In this case, the onset of symptoms then provides a proxy for the time that infection occurred. 
-
-### The Seroincidence Estimator
-
-The **serocalculator** package was designed to calculate the incidence of seroconversion by using the longitudinal seroresponse characteristics. The distribution of serum antibody concentrations in a cross–sectional population sample is calculated as a function of the longitudinal seroresponse and the frequency of seroconversion (or seroincidence). Given the seroresponse, this marginal distribution of antibody concentrations can be fitted to the cross-sectional data and thereby providing a means to estimate the seroincidence.
 
 ## Installing R
 
@@ -51,16 +37,13 @@ If you need to download and install R and/or RStudio, we recommend following the
 
 ## Installing the Serocalculator Package
 
-The **serocalculator** package must be installed in R before first use. As of November 21, 2023, **serocalculator** is still in development. To install the development version, you must install the **devtools** R package and then download **serocalculator** from [GitHub](https://github.com/). Enter the code below into the R console to install both packages:
-
+The **serocalculator** package must be installed in R before first use. 
 
 ```r{eval=FALSE}
-# Install the devtools package and the development version of serocalculator
-install.packages("devtools")
-devtools::install_github("ucd-serg/serocalculator")
+# Install package
+install.packages("serocalculator")
 
 ```
-
 ### Post-installation
 
 Successful installation can be confirmed by loading the package into the RStudio workspaceand exploring help files and manuals distributed with the package:
@@ -83,12 +66,21 @@ packageDescription("serocalculator")
 citation("serocalculator")
 ```
 
-### A Note for Windows Users
+### Development Version
+To install the development version, you must install the **devtools** R package and then download **serocalculator** from [GitHub](https://github.com/). Enter the code below into the R console to install both packages.
 
-Windows users will need to install Rtools, which contains a collection of tools for building and employing R packages that are still in development. This can be done either during the  *devtools* package installation, or independently if *devtools* is already installed. 
+```r{eval=FALSE}
+# Install the devtools package and the development version of serocalculator
+install.packages("devtools")
+devtools::install_github("ucd-serg/serocalculator")
+
+```
+#### A Note for Windows Users
+
+Before launching the development version of **serocalculator**, Windows users will need to install Rtools, which contains a collection of tools for building and employing R packages that are still in development. This can be done either during the  *devtools* package installation, or independently if *devtools* is already installed. 
 
 
-#### During devtools installation:
+##### During devtools installation:
 
 When prompted to install additional build tools, select "Yes" and Rtools will be installed. 
 
@@ -96,7 +88,7 @@ When prompted to install additional build tools, select "Yes" and Rtools will be
 
 [id]: man/figures/Rtools1.png
 
-#### Independently:
+##### Independently:
 
 1. Download Rtools from https://cran.r-project.org/bin/windows/Rtools/
 2. Run the installer
@@ -104,6 +96,8 @@ When prompted to install additional build tools, select "Yes" and Rtools will be
     * During the Rtools installation you may see a window asking you to “Select Additional Tasks”.
     * Do **not** select the box for “Edit the system PATH”. devtools and RStudio should put Rtools on the PATH automatically when it is needed.
     * **Do** select the box for “Save version information to registry”. It should be selected by default.
+    
+
 
 ## Getting Help
 
@@ -111,4 +105,3 @@ If you need assistance or encounter a clear bug, please file an issue with a min
 
 Another great resource is **The Epidemiologist R Handbook**, which includes an introductory page on asking for help with R packages via GitHub: https://epirhandbook.com/en/getting-help.html 
 
-## References

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The **serocalculator** package was designed to use the longitudinal
 response characteristics using a set of modeled parameters
 characterizing the longitudinal response of the selected serum
 antibodies. More details on the underlying methods can be found in
-`vignette("serocalculator")` or [Getting
+[Getting
 Started](https://ucd-serg.github.io/serocalculator/articles/serocalculator.html).
 
 ## Installing R

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The **serocalculator** package was designed to use the longitudinal
 response characteristics using a set of modeled parameters
 characterizing the longitudinal response of the selected serum
 antibodies. More details on the underlying methods can be found in
-`vignette("serocalculator")` or the “Getting Started” link above.
+`vignette("serocalculator")` or [Getting
+Started](https://ucd-serg.github.io/serocalculator/articles/serocalculator.html).
 
 ## Installing R
 

--- a/README.md
+++ b/README.md
@@ -22,55 +22,8 @@ disease.
 The **serocalculator** package was designed to use the longitudinal
 response characteristics using a set of modeled parameters
 characterizing the longitudinal response of the selected serum
-antibodies.
-
-## Methods
-
-The **serocalculator** R package provides a rapid and computationally
-simple method for calculating seroconversion rates, as originally
-published in Simonsen et al. (2009) and Teunis et al. (2012), and
-further developed in subsequent publications by deGraaf et al. (2014),
-Teunis et al. (2016), and Teunis and Eijkeren (2020). In short,
-longitudinal seroresponses from confirmed cases with a known symptom
-onset date are assumed to represent the time course of human serum
-antibodies against a specific pathogen. Therefore, by using these
-longitudinal antibody dynamics with any cross–sectional sample of the
-same antibodies in a human population, an incidence estimate can be
-calculated. Further details are below.
-
-### A Proxy for Infection
-
-While the exact time of infection is impossible to measure in an
-individual, antibody levels measured in a cross–sectional population
-sample can be translated into an estimate of the frequency with which
-seroconversions (infections) occur in the sampled population. So the
-presence of many high antibody concentrations indicates that many people
-in the population likely experienced infection recently, while mostly
-low concentrations indicate a low frequency of infections in the sampled
-population.
-
-In order to interpret the measured cross-sectional antibody
-concentrations in terms of incidence, we must define the antibody
-dynamic over time to understand the generalized antibody response at
-different times since infection. This dynamic must be quantified over
-time to include an initial increase in serum antibody concentration when
-seroconversion occurs, followed by a gradual decrease as antibodies
-wane. In published studies, this information on the time course of the
-serum antibody response has been obtained from longitudinal follow–up
-data in cases who had a symptomatic episode following infection. In this
-case, the onset of symptoms then provides a proxy for the time that
-infection occurred.
-
-### The Seroincidence Estimator
-
-The **serocalculator** package was designed to calculate the incidence
-of seroconversion by using the longitudinal seroresponse
-characteristics. The distribution of serum antibody concentrations in a
-cross–sectional population sample is calculated as a function of the
-longitudinal seroresponse and the frequency of seroconversion (or
-seroincidence). Given the seroresponse, this marginal distribution of
-antibody concentrations can be fitted to the cross-sectional data and
-thereby providing a means to estimate the seroincidence.
+antibodies. More details on the underlying methods can be found in
+`vignette("serocalculator")` or the “Getting Started” link above.
 
 ## Installing R
 
@@ -90,16 +43,10 @@ Grolemund:
 ## Installing the Serocalculator Package
 
 The **serocalculator** package must be installed in R before first use.
-As of November 21, 2023, **serocalculator** is still in development. To
-install the development version, you must install the **devtools** R
-package and then download **serocalculator** from
-[GitHub](https://github.com/). Enter the code below into the R console
-to install both packages:
 
 ``` r
-# Install the devtools package and the development version of serocalculator
-install.packages("devtools")
-devtools::install_github("ucd-serg/serocalculator")
+# Install package
+install.packages("serocalculator")
 ```
 
 ### Post-installation
@@ -127,14 +74,28 @@ packageDescription("serocalculator")
 citation("serocalculator")
 ```
 
-### A Note for Windows Users
+### Development Version
 
-Windows users will need to install Rtools, which contains a collection
-of tools for building and employing R packages that are still in
-development. This can be done either during the *devtools* package
-installation, or independently if *devtools* is already installed.
+To install the development version, you must install the **devtools** R
+package and then download **serocalculator** from
+[GitHub](https://github.com/). Enter the code below into the R console
+to install both packages.
 
-#### During devtools installation:
+``` r
+# Install the devtools package and the development version of serocalculator
+install.packages("devtools")
+devtools::install_github("ucd-serg/serocalculator")
+```
+
+#### A Note for Windows Users
+
+Before launching the development version of **serocalculator**, Windows
+users will need to install Rtools, which contains a collection of tools
+for building and employing R packages that are still in development.
+This can be done either during the *devtools* package installation, or
+independently if *devtools* is already installed.
+
+##### During devtools installation:
 
 When prompted to install additional build tools, select “Yes” and Rtools
 will be installed.
@@ -146,7 +107,7 @@ alt="Click Yes to install Rtools along with the devtools package" />
 the <em>devtools</em> package</figcaption>
 </figure>
 
-#### Independently:
+##### Independently:
 
 1.  Download Rtools from
     <https://cran.r-project.org/bin/windows/Rtools/>
@@ -170,55 +131,3 @@ with a minimal reproducible example on
 Another great resource is **The Epidemiologist R Handbook**, which
 includes an introductory page on asking for help with R packages via
 GitHub: <https://epirhandbook.com/en/getting-help.html>
-
-## References
-
-<div id="refs" class="references csl-bib-body hanging-indent">
-
-<div id="ref-de_Graaf_2014" class="csl-entry">
-
-deGraaf, W. F., M. E. E. Kretzschmar, P. F. M. Teunis, and O. Diekmann.
-2014. “A Two-Phase Within-Host Model for Immune Response and Its
-Application to Serological Profiles of Pertussis.” *Epidemics* 9
-(December): 1–7. <https://doi.org/10.1016/j.epidem.2014.08.002>.
-
-</div>
-
-<div id="ref-Simonsen_2009" class="csl-entry">
-
-Simonsen, J., K. Mølbak, G. Falkenhorst, K. A. Krogfelt, A. Linneberg,
-and P. F. M. Teunis. 2009. “Estimation of Incidences of Infectious
-Diseases Based on Antibody Measurements.” *Statistics in Medicine* 28
-(14): 1882–95. <https://doi.org/10.1002/sim.3592>.
-
-</div>
-
-<div id="ref-Teunis_2020" class="csl-entry">
-
-Teunis, P. F. M., and J. C. H. van Eijkeren. 2020. “Estimation of
-Seroconversion Rates for Infectious Diseases: Effects of Age and Noise.”
-*Statistics in Medicine* 39 (21): 2799–2814.
-<https://doi.org/10.1002/sim.8578>.
-
-</div>
-
-<div id="ref-Teunis_2016" class="csl-entry">
-
-Teunis, P. F. M., J. C. H. van Eijkeren, W. F. de Graaf, A. Bonačić
-Marinović, and M. E. E. Kretzschmar. 2016. “Linking the Seroresponse to
-Infection to Within-Host Heterogeneity in Antibody Production.”
-*Epidemics* 16 (September): 33–39.
-<https://doi.org/10.1016/j.epidem.2016.04.001>.
-
-</div>
-
-<div id="ref-Teunis_2012" class="csl-entry">
-
-Teunis, P. F. M., JCH van Eijkeren, CW Ang, YTHP van Duynhoven, JB
-Simonsen, MA Strid, and W van Pelt. 2012. “Biomarker Dynamics:
-Estimating Infection Rates from Serological Data.” *Statistics in
-Medicine* 31 (20): 2240–48. <https://doi.org/10.1002/sim.5322>.
-
-</div>
-
-</div>

--- a/vignettes/articles/enteric_fever_example.Rmd
+++ b/vignettes/articles/enteric_fever_example.Rmd
@@ -170,6 +170,7 @@ ggplot(data=xs_data, aes(x=age, y=value, color=Country)) +
           )
 
 ```
+
 In this plot, a steeper slope indicates a higher incidence. We can see that the highest burden is in Bangladesh. Nepal has a slightly higher incidence in the older group (higher slope).
 
 
@@ -271,6 +272,6 @@ In our data, we find that the overall estimated seroincidence of enteric fever i
 
 
 ## Acknowledgments
-Special thanks to our collaborators at Aga Khan University  (Karachi, Pakistan).  
+Special thanks to our collaborators at Aga Khan University  (Karachi, Pakistan), Child Health Research Foundation (Dhaka, Bangladesh), and Dhulikhel Hospital, Kathmandu University Hospital (Dhulikhel, Nepal).
 
 ## References

--- a/vignettes/articles/references.bib
+++ b/vignettes/articles/references.bib
@@ -6,7 +6,7 @@
 	publisher = {Elsevier {BV}},
 	volume = {9},
 	pages = {1--7},
-	author = {W.F. deGraaf and M.E.E. Kretzschmar and P.F.M. Teunis and O. Diekmann},
+	author = {WF deGraaf and MEE Kretzschmar and PFM Teunis and O Diekmann},
 	title = {A two-phase within-host model for immune response and its application to serological profiles of pertussis},
 	journal = {Epidemics}
 }
@@ -20,7 +20,7 @@
 	volume = {28},
 	number = {14},
 	pages = {1882--1895},
-	author = {J. Simonsen and K. M{\o}lbak and G. Falkenhorst and K. A. Krogfelt and A. Linneberg and P. F. M. Teunis},
+	author = {J Simonsen and K M{\o}lbak and G Falkenhorst and KA Krogfelt and A Linneberg and PFM Teunis},
 	title = {Estimation of incidences of infectious diseases based on antibody measurements},
 	journal = {Statistics in Medicine}
 }
@@ -34,7 +34,7 @@
 	volume = {31},
 	number = {20},
 	pages = {2240--2248},
-	author = {P.F.M. Teunis  and JCH van Eijkeren and CW Ang and YTHP van Duynhoven and JB Simonsen and MA Strid and W van Pelt},
+	author = {PFM Teunis  and JCH van Eijkeren and CW Ang and YTHP van Duynhoven and JB Simonsen and MA Strid and W van Pelt},
 	title = {Biomarker dynamics: estimating infection rates from serological data},
 	journal = {Statistics in Medicine}
 }
@@ -47,7 +47,7 @@
 	publisher = {Elsevier {BV}},
 	volume = {16},
 	pages = {33--39},
-	author = {P.F.M. Teunis and J.C.H. van Eijkeren and W.F. de Graaf and A. Bona{\v{c}}i{\'{c}} Marinovi{\'{c}} and M.E.E. Kretzschmar},
+	author = {PFM Teunis and JCH van Eijkeren and WF deGraaf and A Bona{\v{c}}i{\'{c}} Marinovi{\'{c}} and MEE Kretzschmar},
 	title = {Linking the seroresponse to infection to within-host heterogeneity in antibody production},
 	journal = {Epidemics}
 }
@@ -61,7 +61,7 @@
 	volume = {8},
 	number = {2},
 	pages = {314--319},
-	author = {Mette Aagaard Strid and J{\o}rgen Engberg and Lena Brandt Larsen and Kamilla Begtrup and K{\aa}re M{\o}lbak and Karen Angeliki Krogfelt},
+	author = {MA Strid and J Engberg and LB Larsen and K Begtrup and K M{\o}lbak and KA Krogfelt},
 	title = {Antibody responses to Campylobacter infections determined by an enzyme-linked immunosorbent assay: 2-year follow-up study of 210 patients},
 	journal = {Clinical Diagnostic Laboratory Immunology}
 }
@@ -72,14 +72,14 @@
 	volume = {3},
 	number = {8},
 	pages = {e578--e587},
-	author = {K. Aiemjoy and Seidman J. C. and Saha S. and Munira S. J. and Islam Sajib M. S. and Sium, S. M. al, Sarkar, A., Alam, N., Zahan, F. N., Kabir, M. S., Tamrakar, D., Vaidya, K., Shrestha, R., Shakya, J., Katuwal, N., Shrestha, S., Yousafzai, M. T., Iqbal, J., Dehraj, I. F., … Andrews, J. R.},
+	author = {K Aiemjoy and JC Seidman and S Saha and SJ Munira and MS Islam Sajib and SM al Sium and A Sarkar and N Alam and FN Zahan  and MS Kabir and D Tamrakar and K Vaidya and R Shrestha and J Shakya  and N Katuwal and S Shrestha and MT Yousafzai and J Iqbal and IF Dehraj and … and JR Andrews },
 	title = {Estimating typhoid incidence from community-based serosurveys: a multicohort study},
 	journal = {The Lancet Microbe}
 }
 
 @article{Aiemjoy_2024_scrub,
   title={Estimating the seroincidence of scrub typhus using antibody dynamics following infection},
-  author={Aiemjoy, Kristen and Katuwal, Nishan and Vaidya, Krista and Shrestha, Sony and Thapa, Melina and Teunis, Peter and Bogoch, Isaac I and Trowbridge, Paul and Kantipong, Pacharee and Blacksell, Stuart D and others},
+  author={K Aiemjoy and N Katuwal and K Vaidya and S Shrestha and M Thapa and PFM Teunis and II Bogoch and P Trowbridge and P Kantipong and SD Blacksell and others},
   journal={American Journal of Tropical Medicine and Hygiene},
   year={Accepted Feb 2024},
 
@@ -92,8 +92,7 @@
 	volume = {28},
 	number = {11},
 	pages = {2316--2320},
-	author = {K. Aiemjoy and John Rumunu and Juma John Hassen, Kirsten E. Wiens, Denise Garrett, Polina Kamenskaya, Jason B. Harris, Andrew S. Azman, Peter Teunis,
-Jessica C. Seidman, Joseph F. Wamala, Jason R. Andrews, Richelle C. Charles},
+	author = {K Aiemjoy and J Rumunu and JJ Hassen and KE Wiens and D Garrett and P Kamenskaya and JB Harris and AS Azman and PFM Teunis and JC Seidman and JF Wamala and JR Andrews and RC Charles},
 	title = {Seroincidence of Enteric Fever,Juba, South Sudan},
 	journal = {Emerging Infectious Diseases}
 }
@@ -104,7 +103,7 @@ Jessica C. Seidman, Joseph F. Wamala, Jason R. Andrews, Richelle C. Charles},
   volume = {39},
   number = {21},
   pages = {2799--2814},
-  author = { P.F.M. Teunis and J.C.H. van Eijkeren},
+  author = {PFM Teunis and JCH van Eijkeren},
   title = {Estimation of seroconversion rates for infectious diseases: Effects of age and noise},
   journal = {Statistics in Medicine}
 }

--- a/vignettes/articles/serocalculator.Rmd
+++ b/vignettes/articles/serocalculator.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteIndexEntry{Methodology}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-bibliography: articles/references.bib
+bibliography: references.bib
 ---
 
 ## Overview

--- a/vignettes/serocalculator.Rmd
+++ b/vignettes/serocalculator.Rmd
@@ -1,0 +1,27 @@
+---
+title: "Methodology"
+description: >
+  A summary of the methods behind serocalculator.
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Methodology}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+bibliography: articles/references.bib
+---
+
+## Overview
+
+The **serocalculator** R package provides a rapid and computationally simple method for calculating seroconversion rates, as originally published in @Simonsen_2009 and @Teunis_2012, and further developed in subsequent publications by @de_Graaf_2014, @Teunis_2016, and @Teunis_2020. In short, longitudinal seroresponses from confirmed cases with a known symptom onset date are assumed to represent the time course of human serum antibodies against a specific pathogen. Therefore, by using these longitudinal antibody dynamics with any cross–sectional sample of the same antibodies in a human population, an incidence estimate can be calculated. Further details are below.
+
+### A Proxy for Infection
+
+While the exact time of infection is impossible to measure in an individual, antibody levels measured in a cross–sectional population sample can be translated into an estimate of the frequency with which seroconversions (infections) occur in the sampled population. So the presence of many high antibody concentrations indicates that many people in the population likely experienced infection recently, while mostly low concentrations indicate a low frequency of infections in the sampled population.
+
+In order to interpret the measured cross-sectional antibody concentrations in terms of incidence, we must define the antibody dynamic over time to understand the generalized antibody response at different times since infection. This dynamic must be quantified over time to include an initial increase in serum antibody concentration when seroconversion occurs, followed by a gradual decrease as antibodies wane. In published studies, this information on the time course of the serum antibody response has been obtained from longitudinal follow–up data in cases who had a symptomatic episode following infection. In this case, the onset of symptoms then provides a proxy for the time that infection occurred.
+
+### The Seroincidence Estimator
+
+The **serocalculator** package was designed to calculate the incidence of seroconversion by using the longitudinal seroresponse characteristics. The distribution of serum antibody concentrations in a cross–sectional population sample is calculated as a function of the longitudinal seroresponse and the frequency of seroconversion (or seroincidence). Given the seroresponse, this marginal distribution of antibody concentrations can be fitted to the cross-sectional data and thereby providing a means to estimate the seroincidence.
+
+## References


### PR DESCRIPTION
A few last things I wanted to polish before initial CRAN submission....
- Moved methods to "serocalculator.Rmd" vignette and "getting started" tab
- Reorganized Readme and clarified installation instructions vs development version
- Standardized author name formatting in bibliography
- Fixed acknowledgements in enteric fever vignette