### PR TITLE
simplify fdev deprecation

### DIFF
--- a/R/f_dev.r
+++ b/R/f_dev.r
@@ -3,23 +3,21 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `fdev()` was renamed to `f_dev()` to create a more
+#' `fdev()` was renamed to [f_dev()] to create a more
 #' consistent API.
 #'
 #' @keywords internal
 #'
 #' @export
-fdev <- Vectorize(
-  vectorize.args = "lambda",
-  function(
-      lambda,
-      csdata,
-      lnpars,
-      cond) {
-    lifecycle::deprecate_warn("1.0.0", "fdev()", "f_dev()")
-    f_dev(lambda, csdata, lnpars, cond)
-  }
-)
+fdev <- function(lambda,
+                 csdata,
+                 lnpars,
+                 cond)
+{
+  lifecycle::deprecate_warn("1.0.0", "fdev()", "f_dev()")
+  f_dev(lambda, csdata, lnpars, cond)
+}
+
 
 #  Utility functions: interface with C lib serocalc.so
 

--- a/man/fdev.Rd
+++ b/man/fdev.Rd
@@ -9,7 +9,7 @@ fdev(lambda, csdata, lnpars, cond)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{fdev()} was renamed to \code{f_dev()} to create a more
+\code{fdev()} was renamed to \code{\link[=f_dev]{f_dev()}} to create a more
 consistent API.
 }
 \keyword{internal}


### PR DESCRIPTION
simplifying; please follow this pattern (no `Vectorize()` needed in deprecated version).