### PR TITLE
set GitHub actions to treat warnings in test as errors

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,4 +46,5 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          error-on: '"warning"'
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -9,4 +9,4 @@
 library(testthat)
 library(serocalculator)
 
-test_check("serocalculator")
+test_check("serocalculator", stop_on_warning = TRUE)


### PR DESCRIPTION
We have been missing a lot of important warnings thrown by `testthat` (currently 31 warnings). This PR changes the GitHub Actions settings so that those warnings become errors.