### PR TITLE
link to new function names

### DIFF
--- a/R/f_dev.r
+++ b/R/f_dev.r
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `fdev()` was renamed to `f_dev()` to create a more
+#' `fdev()` was renamed to [f_dev()] to create a more
 #' consistent API.
 #'
 #' @keywords internal

--- a/R/llik.R
+++ b/R/llik.R
@@ -2,7 +2,7 @@
 #'
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `llik()` was renamed to `log_likelihood()` to create a more
+#' `llik()` was renamed to [log_likelihood()] to create a more
 #' consistent API.
 #'
 #' @keywords internal

--- a/man/fdev.Rd
+++ b/man/fdev.Rd
@@ -9,7 +9,7 @@ fdev(lambda, csdata, lnpars, cond)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{fdev()} was renamed to \code{f_dev()} to create a more
+\code{fdev()} was renamed to \code{\link[=f_dev]{f_dev()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/llik.Rd
+++ b/man/llik.Rd
@@ -18,7 +18,7 @@ llik(
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 }
 \details{
-\code{llik()} was renamed to \code{log_likelihood()} to create a more
+\code{llik()} was renamed to \code{\link[=log_likelihood]{log_likelihood()}} to create a more
 consistent API.
 }
 \keyword{internal}


### PR DESCRIPTION
adding hyperlinks from `llik` documentation to `log_likelihood` documentation, and similarly for `fdev`->`f_dev`