### PR TITLE
specify R v4.4.1 until issues with 4.4.2 and Rcpp are resolved.

### DIFF
--- a/.github/workflows/R-check-docs.yml
+++ b/.github/workflows/R-check-docs.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: '4.4.1'
 
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.4.1'
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
 
 ## Internal changes
 
+* Specified to use R version 4.4.1 for linting and checking Rd files (#313)
+
 * Added online preview builds for PRs that change the `pkgdown` website (#309)
 
 * Added `test-autoplot.pop_data` test (#234)


### PR DESCRIPTION
Since R 4.4.2 released this morning, the `document` and `lint-changed-files` GitHub actions have started failing due to failure to compile Rcpp (as noted in https://github.com/RcppCore/Rcpp/issues/1341). An update to Rcpp will hopefully be released on CRAN shortly, but in the meantime, we can avoid the issue by using R v4.4.1 to run these GHAs.