### PR TITLE
Quickfix graph curve params example

### DIFF
--- a/R/graph.curve.params.R
+++ b/R/graph.curve.params.R
@@ -7,15 +7,14 @@
 #' @export
 #'
 #' @examples
-#' \dontrun{
 #' curve <-
 #'   typhoid_curves_nostrat_100 |>
-#'   filter(antigen_iso %in% c("HlyE_IgA", "HlyE_IgG"))
+#'   dplyr::filter(antigen_iso %in% c("HlyE_IgA", "HlyE_IgG"))
 #'
 #' plot1 <- graph.curve.params(curve)
 #'
 #' print(plot1)
-#' }
+#'
 graph.curve.params <- function(
     curve_params,
     antigen_isos = unique(curve_params$antigen_iso),

--- a/man/graph.curve.params.Rd
+++ b/man/graph.curve.params.Rd
@@ -24,13 +24,12 @@ a \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object
 Graph estimated antibody decay curve
 }
 \examples{
-\dontrun{
 curve <-
   typhoid_curves_nostrat_100 |>
-  filter(antigen_iso \%in\% c("HlyE_IgA", "HlyE_IgG"))
+  dplyr::filter(antigen_iso \%in\% c("HlyE_IgA", "HlyE_IgG"))
 
 plot1 <- graph.curve.params(curve)
 
 print(plot1)
-}
+
 }


### PR DESCRIPTION
I think this patch fixes the error you were getting in `graph.curve.params()`