### PR TITLE
Update branches-or-tags-to-list regex pattern

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -290,7 +290,7 @@ jobs:
           path: ${{ github.event.repository.name }}
           default-landing-page: "latest-tag"
           refs-order: "main latest-tag"
-          branches-or-tags-to-list: '^main$|^latest-tag$|^v([0-9]+\\.)?([0-9]+\\.)?([0-9]+)$'
+          branches-or-tags-to-list: '^main$|^latest-tag$|^(serocalculator |v)([0-9]+\\.)?([0-9]+\\.)?([0-9]+)$'
 
   upload-release-assets:
     name: Upload documentation assets 🔼


### PR DESCRIPTION
This pull request updates the documentation workflow configuration to include an additional pattern for listing branches or tags in the docs site. Now, branches or tags starting with `serocalculator` followed by a version number will also be included, in addition to the existing patterns.

- **Documentation workflow configuration:**
  * Updated the `branches-or-tags-to-list` regex in `.github/workflows/docs.yaml` to include branches or tags that start with `serocalculator` and a version number, alongside the previous `main`, `latest-tag`, and `vX.Y.Z` patterns.