### PR TITLE
Skip Claude review when triggered by a bot

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip when a bot triggered the workflow (e.g. claude[bot] pushed a
+    # commit). The action otherwise hard-fails with
+    # "Workflow initiated by non-human actor".
+    if: github.event.sender.type != 'Bot'
 
     runs-on: ubuntu-latest
     permissions:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: serocalculator
 Title: Estimating Infection Rates from Serological Data
-Version: 1.4.0.9010
+Version: 1.4.0.9011
 Authors@R: c(
     person("Kristina", "Lai", , "kwlai@ucdavis.edu", role = c("aut", "cre")),
     person("Chris", "Orwa", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # serocalculator (development version)
 
+## Internal
+
+* Claude PR review workflow now skips (rather than hard-failing) when triggered by a bot (e.g. `claude[bot]` pushing a commit). (#519)
+
 ## Bug fixes
 
 * `load_noise_params()` and `load_sr_params()` now fail gracefully with informative messages when internet resources are unavailable, complying with CRAN policy (#505)


### PR DESCRIPTION
## Summary
- When a bot (e.g. `claude[bot]`) pushes a commit, the Claude review action hard-fails with `Workflow initiated by non-human actor`, surfacing as a red check on the PR.
- Add a job-level `if: github.event.sender.type != 'Bot'` so the review skips cleanly instead.
- This also needs to land on `main` so the workflow-file-validation check on PR #518 stops blocking that branch — `claude-code-action` requires the workflow on the PR head to match the version on the default branch.

## Test plan
- [ ] Workflow lints (GitHub renders the YAML without errors).
- [ ] After merge, re-run `claude-review` on PR #518 and confirm the workflow-validation error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)