### PR TITLE
[verify] @claude PR-trigger path (do not merge)

### DIFF
--- a/.github/claude-verify.md
+++ b/.github/claude-verify.md
@@ -4,4 +4,4 @@ This file exists only to open a verification PR for the `@claude` agent
 workflow's PR-trigger path (checkout PR branch -> agent commits -> post-step
 pushes). It will be deleted; do not merge.
 
-Intentional typo for @claude to fix: serocalculater
+Intentional typo for @claude to fix: serocalculator

--- a/.github/claude-verify.md
+++ b/.github/claude-verify.md
@@ -1,0 +1,7 @@
+# Claude PR-trigger verification (throwaway)
+
+This file exists only to open a verification PR for the `@claude` agent
+workflow's PR-trigger path (checkout PR branch -> agent commits -> post-step
+pushes). It will be deleted; do not merge.
+
+Intentional typo for @claude to fix: serocalculater


### PR DESCRIPTION
Throwaway draft PR to verify the merged `@claude` agent workflow's PR-trigger path (the unverified finding #1 from #523): on a PR-context `@claude` mention, does the agent's commit land on the PR branch (`gh pr checkout` → commit → post-step push)?

Plan: comment `@claude` asking it to fix the intentional typo in `.github/claude-verify.md`, then confirm a new commit appears on this branch and a review is re-dispatched. **Will be closed without merging.**