### PR TITLE
Fix ported @claude workflow config (allowed_bots + agent file tools)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -105,6 +105,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # When claude.yml routes an `@claude review` comment here, it
+          # dispatches this workflow via `gh workflow run`, so the run's
+          # actor is github-actions[bot]. Without allowing that bot the
+          # action aborts with "Workflow initiated by non-human actor"
+          # and posts no review. The job `if:` already restricts dispatched
+          # runs to same-repo, non-Dependabot PRs, so accepting the bot
+          # dispatcher here is safe.
+          allowed_bots: "github-actions[bot]"
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           # `claude-code-plugins` is a branch name, not a version tag.
           # Intentionally unpinned so we pick up future improvements to the

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -225,9 +225,13 @@ jobs:
           # is restricted to the namespaces used by the pre-commit checklist —
           # accepting that devtools::check/document runs project R code that
           # can `system()`; the real containment is the trusted-author gate
-          # in the job `if:` above.
+          # in the job `if:` above. The file tools (Read/Glob/Grep/Edit/
+          # MultiEdit/Write) are included so the agent can actually make code
+          # changes — the action runs non-interactively, auto-approving only
+          # tools listed here, so without them the agent can read/run but not
+          # edit files and falls back to posting a diff for manual application.
           claude_args: |
-            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'devtools::test*'),Bash(Rscript -e 'spelling::spell_check*'),Bash(Rscript -e 'roxygen2::roxygenise*'),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*)" --disallowedTools "Bash(git push:*),Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin:*),Bash(git push -u origin:*)"
+            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'devtools::test*'),Bash(Rscript -e 'spelling::spell_check*'),Bash(Rscript -e 'roxygen2::roxygenise*'),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*),Read,Glob,Grep,Edit,MultiEdit,Write" --disallowedTools "Bash(git push:*),Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin:*),Bash(git push -u origin:*)"
 
       # Push the commits Claude made on the PR branch. The agent isn't granted
       # `git push`, so this post-step does it — mirroring how the issue-branch

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: serocalculator
 Title: Estimating Infection Rates from Serological Data
-Version: 1.4.0.9012
+Version: 1.4.0.9013
 Authors@R: c(
     person("Kristina", "Lai", , "kwlai@ucdavis.edu", role = c("aut", "cre")),
     person("Chris", "Orwa", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Internal
 
+* `claude-code-review.yml` now sets `allowed_bots: github-actions[bot]` so the review still runs (and posts feedback) when `claude.yml` re-dispatches it on an `@claude review` comment; previously the bot-initiated dispatch aborted with "Workflow initiated by non-human actor".
 * Ported the `@claude` agent and PR-review GitHub Actions workflows (plus Claude/Copilot config: `CLAUDE.md`, `.claude/` settings and slash commands, and path-scoped `.github/instructions/`) from the UCD-SERG `qwt` template, adapted to this package. (#523)
 * Claude PR review workflow now skips (rather than hard-failing) when triggered by a bot (e.g. `claude[bot]` pushing a commit). (#519)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Internal
 
 * `claude-code-review.yml` now sets `allowed_bots: github-actions[bot]` so the review still runs (and posts feedback) when `claude.yml` re-dispatches it on an `@claude review` comment; previously the bot-initiated dispatch aborted with "Workflow initiated by non-human actor".
+* `claude.yml` now grants the `@claude` agent the file tools (`Read`/`Glob`/`Grep`/`Edit`/`MultiEdit`/`Write`) in `--allowedTools`; previously the agent could run checks/git/gh but not edit files, so it fell back to posting diffs for manual application.
 * Ported the `@claude` agent and PR-review GitHub Actions workflows (plus Claude/Copilot config: `CLAUDE.md`, `.claude/` settings and slash commands, and path-scoped `.github/instructions/`) from the UCD-SERG `qwt` template, adapted to this package. (#523)
 * Claude PR review workflow now skips (rather than hard-failing) when triggered by a bot (e.g. `claude[bot]` pushing a commit). (#519)
 


### PR DESCRIPTION
## Summary

When `claude.yml` routes an `@claude review` **comment** to `claude-code-review.yml` (via `gh workflow run`), the dispatched run's actor is `github-actions[bot]`. `claude-code-action` then aborts with:

```
Workflow initiated by non-human actor: github-actions (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

so the review runs but posts **no feedback** (observed on #529 — the dispatched review run failed; only the "👀 Picked up" ack was visible).

Fix: set `allowed_bots: "github-actions[bot]"` on the review action so the bot-dispatched `workflow_dispatch` run is accepted. The job `if:` already restricts dispatched runs to same-repo, non-Dependabot PRs, so this is safe.

Note: the auto `pull_request`-triggered reviews (on open/push) were unaffected — only the `@claude review` comment → dispatch path hit this. This gap also exists upstream in `qwt`; I'll flag it there.

## Test plan
- [ ] Merge, then comment `@claude review` on a PR and confirm the dispatched review now runs and posts feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)