### PR TITLE
ci(lint): fix invalid GitHub PAT format in lint-changed-files

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -10,8 +10,6 @@ permissions: read-all
 jobs:
   lint-changed-files:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -37,11 +35,17 @@ jobs:
 
       - name: Extract and lint files changed by this PR
         run: |
-          files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          Sys.unsetenv("GITHUB_PAT")
+
+          files <- gh::gh(
+            "GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files",
+            .token = Sys.getenv("GITHUB_TOKEN")
+          )
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)
           exclusions_list <- as.list(setdiff(all_files, changed_files))
           lintr::lint_package(exclusions = exclusions_list)
         shell: Rscript {0}
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           LINTR_ERROR_ON_LINT: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: serocalculator
 Title: Estimating Infection Rates from Serological Data
-Version: 1.4.0.9013
+Version: 1.4.0.9014
 Authors@R: c(
     person("Kristina", "Lai", , "kwlai@ucdavis.edu", role = c("aut", "cre")),
     person("Chris", "Orwa", role = "aut"),

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -63,6 +63,7 @@ forall
 frac
 geoms
 ggproto
+gh
 hemolysin
 infty
 insightsengineering


### PR DESCRIPTION
## Problem

The `lint-changed-files` job fails on PRs with:

```
Error in `validate_gh_pat()`:
! Invalid GitHub PAT format
```

**Root cause:** the R `gh` package reads the `GITHUB_PAT` env var and runs `validate_gh_pat()` on it. The auto-provisioned `secrets.GITHUB_TOKEN` is now a `ghs_`-style server-to-server token whose format `gh` rejects (it only accepts 40-hex, `ghp_`, or `github_pat_`). So the "lint files changed by this PR" step aborts before any linting runs.

## Fix

Unset `GITHUB_PAT` and pass the token explicitly via `.token=` (which bypasses the PAT format check), setting `GITHUB_TOKEN: ${{ github.token }}` on the step. Mirrors the fix in UCD-SERG/shigella and UCD-SERG/serodynamics (#242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)