### PR TITLE
Change "seroconversion" to "seroincidence" in plot axis titles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: serocalculator
 Title: Estimating Infection Rates from Serological Data
-Version: 1.4.0.9013
+Version: 1.4.0.9014
 Authors@R: c(
     person("Kristina", "Lai", , "kwlai@ucdavis.edu", role = c("aut", "cre")),
     person("Chris", "Orwa", role = "aut"),
@@ -81,3 +81,4 @@ Roxygen: list(markdown = TRUE, roclets = c("collate", "rd", "namespace"))
 Remotes: 
     d-morrison/snapr
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: serocalculator
 Title: Estimating Infection Rates from Serological Data
-Version: 1.4.0.9014
+Version: 1.4.0.9015
 Authors@R: c(
     person("Kristina", "Lai", , "kwlai@ucdavis.edu", role = c("aut", "cre")),
     person("Chris", "Orwa", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -81,4 +81,3 @@ Roxygen: list(markdown = TRUE, roclets = c("collate", "rd", "namespace"))
 Remotes: 
     d-morrison/snapr
 Config/roxygen2/version: 8.0.0
-RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+* Removed lingering terminology discrepancies
 * `load_noise_params()` and `load_sr_params()` now fail gracefully with informative messages when internet resources are unavailable, complying with CRAN policy (#505)
 * Added Version Crosswalk article to pkgdown website to help users migrate code from v1.3.0 to v1.4.0
   - Provides clear tables comparing old and new function names

--- a/R/strat_ests_barplot.R
+++ b/R/strat_ests_barplot.R
@@ -26,7 +26,7 @@ strat_ests_barplot <- function(
     alpha = 0.7,
     CIs = FALSE, # nolint: object_name_linter
     title = NULL,
-    xlab = "Seroconversion rate per 1000 person-years",
+    xlab = "Seroincidence rate per 1000 person-years",
     ylab = yvar,
     fill_lab = NULL,
     color_palette = NULL,

--- a/R/strat_ests_scatterplot.R
+++ b/R/strat_ests_scatterplot.R
@@ -57,7 +57,7 @@ strat_ests_scatterplot <- function(
       col = .data[[color_var]]
     ) +
     ggplot2::xlab(xvar) +
-    ggplot2::ylab("Estimated incidence rate") +
+    ggplot2::ylab("Estimated seroincidence rate") +
     ggplot2::theme_linedraw() +
     ggplot2::theme(
       panel.grid.minor.x = ggplot2::element_blank(),

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -63,6 +63,7 @@ forall
 frac
 geoms
 ggproto
+gh
 hemolysin
 infty
 insightsengineering

--- a/man/strat_ests_barplot.Rd
+++ b/man/strat_ests_barplot.Rd
@@ -11,7 +11,7 @@ strat_ests_barplot(
   alpha = 0.7,
   CIs = FALSE,
   title = NULL,
-  xlab = "Seroconversion rate per 1000 person-years",
+  xlab = "Seroincidence rate per 1000 person-years",
   ylab = yvar,
   fill_lab = NULL,
   color_palette = NULL,

--- a/tests/testthat/_snaps/autoplot.summary.seroincidence.by/strat-est-barplot-palette.svg
+++ b/tests/testthat/_snaps/autoplot.summary.seroincidence.by/strat-est-barplot-palette.svg
@@ -75,7 +75,7 @@
 <text x='55.31' y='555.64' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='6.12px' lengthAdjust='spacingAndGlyphs'>0</text>
 <text x='261.01' y='555.64' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>200</text>
 <text x='466.71' y='555.64' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>400</text>
-<text x='350.34' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='212.21px' lengthAdjust='spacingAndGlyphs'>Seroconversion rate per 1000 person-years</text>
+<text x='350.34' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='205.48px' lengthAdjust='spacingAndGlyphs'>Seroincidence rate per 1000 person-years</text>
 <text transform='translate(13.05,274.31) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='35.47px' lengthAdjust='spacingAndGlyphs'>ageCat</text>
 <rect x='666.61' y='251.55' width='47.91' height='45.52' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <rect x='672.09' y='257.03' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />

--- a/tests/testthat/_snaps/autoplot.summary.seroincidence.by/strat-est-barplot.svg
+++ b/tests/testthat/_snaps/autoplot.summary.seroincidence.by/strat-est-barplot.svg
@@ -75,7 +75,7 @@
 <text x='55.31' y='555.64' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='6.12px' lengthAdjust='spacingAndGlyphs'>0</text>
 <text x='261.01' y='555.64' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>200</text>
 <text x='466.71' y='555.64' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='18.35px' lengthAdjust='spacingAndGlyphs'>400</text>
-<text x='350.34' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='212.21px' lengthAdjust='spacingAndGlyphs'>Seroconversion rate per 1000 person-years</text>
+<text x='350.34' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='205.48px' lengthAdjust='spacingAndGlyphs'>Seroincidence rate per 1000 person-years</text>
 <text transform='translate(13.05,274.31) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='35.47px' lengthAdjust='spacingAndGlyphs'>ageCat</text>
 <rect x='666.61' y='251.55' width='47.91' height='45.52' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <rect x='672.09' y='257.03' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />

--- a/tests/testthat/_snaps/autoplot.summary.seroincidence.by/strat-est-plot-ci-lines.svg
+++ b/tests/testthat/_snaps/autoplot.summary.seroincidence.by/strat-est-plot-ci-lines.svg
@@ -66,7 +66,7 @@
 <text x='374.88' y='516.90' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='17.61px' lengthAdjust='spacingAndGlyphs'>5-15</text>
 <text x='587.16' y='516.90' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='14.93px' lengthAdjust='spacingAndGlyphs'>16+</text>
 <text x='374.88' y='529.04' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='35.47px' lengthAdjust='spacingAndGlyphs'>ageCat</text>
-<text transform='translate(13.05,264.35) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='120.47px' lengthAdjust='spacingAndGlyphs'>Estimated incidence rate</text>
+<text transform='translate(13.05,264.35) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='141.87px' lengthAdjust='spacingAndGlyphs'>Estimated seroincidence rate</text>
 <rect x='287.22' y='542.28' width='175.32' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='292.70' y='560.19' style='font-size: 11.00px; font-family: sans;' textLength='79.50px' lengthAdjust='spacingAndGlyphs'>Catchment Area</text>
 <rect x='377.68' y='547.76' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />

--- a/tests/testthat/_snaps/autoplot.summary.seroincidence.by/strat-est-plot-ci.svg
+++ b/tests/testthat/_snaps/autoplot.summary.seroincidence.by/strat-est-plot-ci.svg
@@ -64,7 +64,7 @@
 <text x='374.88' y='516.90' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='17.61px' lengthAdjust='spacingAndGlyphs'>5-15</text>
 <text x='587.16' y='516.90' text-anchor='middle' style='font-size: 8.80px; font-family: sans;' textLength='14.93px' lengthAdjust='spacingAndGlyphs'>16+</text>
 <text x='374.88' y='529.04' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='35.47px' lengthAdjust='spacingAndGlyphs'>ageCat</text>
-<text transform='translate(13.05,264.35) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='120.47px' lengthAdjust='spacingAndGlyphs'>Estimated incidence rate</text>
+<text transform='translate(13.05,264.35) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='141.87px' lengthAdjust='spacingAndGlyphs'>Estimated seroincidence rate</text>
 <rect x='287.22' y='542.28' width='175.32' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <text x='292.70' y='560.19' style='font-size: 11.00px; font-family: sans;' textLength='79.50px' lengthAdjust='spacingAndGlyphs'>Catchment Area</text>
 <rect x='377.68' y='547.76' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />


### PR DESCRIPTION
Fixing a lingering "seroconversion rate" mention in strat_est_barplot