### PR TITLE
Update GITHUB_PAT secret in lint workflow

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -11,7 +11,7 @@ jobs:
   lint-changed-files:
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration. The environment variable `GITHUB_PAT` is now set to use the `GITHUB_PAT` secret instead of the default `GITHUB_TOKEN` secret.

- [`.github/workflows/lint-changed-files.yaml`](diffhunk://#diff-1ccd412ff77331b32e1845159d1c5b2fa5799f9b17732a0f59dccb879bd68634L14-R14): Updated the `GITHUB_PAT` environment variable to use `secrets.GITHUB_PAT` for improved secret management.