### PR TITLE
Use d-morrison/macros submodule for methodology vignette (#534)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -39,3 +39,5 @@ allpopsamples_hlye.csv$
 ^\.lintr\.R$
 ^CLAUDE\.md$
 ^\.claude$
+^macros$
+^\.gitmodules$

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -84,6 +84,7 @@ jobs:
           ref: ${{ steps.branch-name.outputs.head_ref_branch }}
           path: ${{ github.event.repository.name }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          submodules: true
 
       - name: Checkout repo 🛎
         uses: actions/checkout@v4.3.1
@@ -91,6 +92,7 @@ jobs:
         with:
           ref: ${{ steps.current-branch-or-tag.outputs.ref-name }}
           path: ${{ github.event.repository.name }}
+          submodules: true
 
       - name: Check commit message 💬
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,6 +14,8 @@ on:
       - DESCRIPTION
       - "**.md"
       - "**.Rmd"
+      - "**.qmd"
+      - "macros"
       - "man/**"
       - "LICENSE.*"
       - NAMESPACE
@@ -36,6 +38,8 @@ on:
       - DESCRIPTION
       - "**.md"
       - "**.Rmd"
+      - "**.qmd"
+      - "macros"
       - "man/**"
       - "LICENSE.*"
       - NAMESPACE

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "macros"]
+	path = macros
+	url = https://github.com/d-morrison/macros

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: serocalculator
 Title: Estimating Infection Rates from Serological Data
-Version: 1.4.0.9013
+Version: 1.4.0.9014
 Authors@R: c(
     person("Kristina", "Lai", , "kwlai@ucdavis.edu", role = c("aut", "cre")),
     person("Chris", "Orwa", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Internal
 
+* The `methodology` vignette's LaTeX macros now come from the shared
+  [`d-morrison/macros`](https://github.com/d-morrison/macros) git submodule
+  (included via `{{< include ../macros/macros.qmd >}}`) instead of a local
+  `vignettes/articles/_macros.qmd`. The deck adopts the shared macro
+  vocabulary (e.g. `\dens` for the density function in place of the local
+  `\pdf`). (#534)
 * `claude-code-review.yml` now sets `allowed_bots: github-actions[bot]` so the review still runs (and posts feedback) when `claude.yml` re-dispatches it on an `@claude review` comment; previously the bot-initiated dispatch aborted with "Workflow initiated by non-human actor".
 * `claude.yml` now grants the `@claude` agent the file tools (`Read`/`Glob`/`Grep`/`Edit`/`MultiEdit`/`Write`) in `--allowedTools`; previously the agent could run checks/git/gh but not edit files, so it fell back to posting diffs for manual application.
 * Added the `iterate` Claude Code skill (`.claude/skills/iterate/`) for driving a PR to a clean review verdict.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -63,6 +63,7 @@ forall
 frac
 geoms
 ggproto
+gh
 hemolysin
 infty
 insightsengineering
@@ -126,6 +127,7 @@ serosurvey
 serosurveys
 smp
 subfigures
+submodule
 th
 tibble
 titers

--- a/vignettes/articles/_antibody-response-model.qmd
+++ b/vignettes/articles/_antibody-response-model.qmd
@@ -1,7 +1,7 @@
 # Modeling the seroresponse kinetics curve
 
 ::: notes
-Now, we need a model for the antibody response to infection, $\pdf(Y=y|T=t)$.
+Now, we need a model for the antibody response to infection, $\dens(Y=y|T=t)$.
 The current version of the `{serocalculator}` package uses
 a two-phase model for
 the shape of the seroresponse [@Teunis_2016].

--- a/vignettes/articles/_macros.qmd
+++ b/vignettes/articles/_macros.qmd
@@ -1,9 +1,0 @@
-\def\NA{\text{NA}}
-\def\pdf{\mathbb{p}}
-\def\pmf{\mathbb{P}}
-\def\Lik{\mathcal{L}}
-\def\llik{\ell}
-\renewcommand{\vec}[1]{\mathbf{#1}}
-\providecommand{\expf}[1]{\exp{\left\{#1\right\}}}
-\providecommand{\logf}[1]{\log{\left\{#1\right\}}}
-\providecommand{\invf}[1]{#1^{-1}}

--- a/vignettes/articles/_sec-latent-likelihood.qmd
+++ b/vignettes/articles/_sec-latent-likelihood.qmd
@@ -15,7 +15,7 @@ to find the maximum likelihood estimate:
 
 :::: incremental
 
-* $$\Lik^*(\lambda) = \prod_{i=1}^n \pdf(T=t_i) = \prod_{i=1}^n \lambda \exp(-\lambda t_i)$$
+* $$\Lik^*(\lambda) = \prod_{i=1}^n \dens(T=t_i) = \prod_{i=1}^n \lambda \expf{-\lambda t_i}$$
 
 * $$\llik^*(\lambda) = \logf{\Lik^*(\lambda)} = \sum_{i=1}^n \logf{\lambda} -\lambda t_i$$
 

--- a/vignettes/methodology.qmd
+++ b/vignettes/methodology.qmd
@@ -7,7 +7,7 @@ vignette: >
 bibliography: references.bib
 ---
 
-{{< include articles/_macros.qmd >}}
+{{< include ../macros/macros.qmd >}}
 
 # Overview
 
@@ -143,12 +143,12 @@ Under those assumptions:
 
 * $T$ has an **exponential distribution**:
 
-$$\pdf(T=t) = \lambda \expf{-\lambda t}$$
+$$\dens(T=t) = \lambda \expf{-\lambda t}$$
 
   * More precisely, the distribution is exponential 
   **truncated by age** at observation ($a$):
 
-$$\pdf(T=t|A=a) = 1_{t \in[0,a]}\lambda \expf{-\lambda t} + 1_{t = \NA} \expf{-\lambda a}$$
+$$\dens(T=t|A=a) = 1_{t \in[0,a]}\lambda \expf{-\lambda t} + 1_{t = \NA} \expf{-\lambda a}$$
 
 * the rate parameter $\lambda$ is the incidence rate
 
@@ -164,7 +164,7 @@ an individual was **last** infected $t$ days ago, $p(T=t)$,
 is equal to the probability of being infected at time $t$ 
 (i.e., the incidence rate at time $t$, $\lambda$) 
 times the probability of not being infected after time $t$, 
-which turns out to be $\exp(-\lambda t)$.
+which turns out to be $\expf{-\lambda t}$.
 
 The distribution of $T$ is truncated by the patient's birth date;
 the probability that they have never been infected is
@@ -262,7 +262,7 @@ we are going to consider all possible values of $t$ for each individual.
 We need to link the data we actually observed to the incidence rate.
 
 The likelihood of an individual's observed data, 
-$\pdf(Y=y)$, 
+$\dens(Y=y)$, 
 can be expressed as an integral over 
 the joint likelihood of $Y$ and $T$ 
 (using the Law of Total Probability):
@@ -270,7 +270,7 @@ the joint likelihood of $Y$ and $T$
 
 ::: incremental
 
-* $$\pdf(Y=y) = \int_t \pdf(Y=y,T=t)dt$$
+* $$\dens(Y=y) = \int_t \dens(Y=y,T=t)dt$$
 
 :::: notes
 Further, we can express the joint probability $p(Y=y,T=t)$ as the product of 
@@ -279,7 +279,7 @@ $p(Y=y|T=t)$ the "antibody response curve after infection".
 That is:
 ::::
 
-* $$\pdf(Y=y,T=t) = \pdf(Y=y|T=t) \pdf(T=t)$$
+* $$\dens(Y=y,T=t) = \dens(Y=y|T=t) \dens(T=t)$$
 
 :::
 


### PR DESCRIPTION
Closes #534.

Replaces the local `vignettes/articles/_macros.qmd` with the shared [`d-morrison/macros`](https://github.com/d-morrison/macros) git submodule, so the methodology deck draws its LaTeX macros from one maintained source.

## Changes

- **Add the `macros` submodule** at the repo root, included via `{{< include ../macros/macros.qmd >}}`. `macros/` and `.gitmodules` are added to `.Rbuildignore` (mirroring how `_extensions` is handled), so R CMD check is unaffected.
- **Adopt the submodule's vocabulary** in the deck:
  - `\pdf` → `\dens` for the density function. The submodule reserves `\pdf` for *f* and uses `\dens` (= `\operatorname{p}`) for the density — which renders a roman *p*, matching the literal `p(...)` already used in the figure captions (more consistent than the old blackboard `𝕡`).
  - literal `\exp(...)` → `\expf{...}`, because the submodule redefines `\exp` to take a braced argument (leaving `\exp(...)` would break).
  - `\vec` now renders as the submodule's tilde, `\Lik` as `\mathscr` — accepted house style.
- **Delete** the local `_macros.qmd`.

## Upstream dependency

`\NA` was the only macro the deck used that the submodule lacked. It's added upstream in **d-morrison/macros#60**, and this PR pins the submodule to that commit (`b8d1830`) so the deck renders correctly right now. **Once #60 merges, bump the submodule pointer to `main`.**

## Verification

A `quarto render` of the deck confirms every custom macro expands — e.g. `\dens(T=t)` → `\operatorname{p}(T=t)`, `\NA` → `\text{NA}`, `\expf{...}` → the submodule expansion — with no unexpanded leftovers. `lintr` and `spelling::spell_check_package()` are clean.

## Note on sequencing

This branches off `main`, so it overlaps with #527 (which also rewrites `methodology.qmd` / the macros file). Whichever merges second will need a conflict resolution; the `\pdf`→`\dens` treatment will need re-applying to #527's expanded deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)