### PR TITLE
CI: use central d-morrison/gha check-news reusable workflow

### DIFF
--- a/.github/workflows/news.yaml
+++ b/.github/workflows/news.yaml
@@ -1,14 +1,11 @@
 name: Check NEWS.md Changelog
+
 on:
   pull_request:
     types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+
 jobs:
-  Check-Changelog:
-    name: Check Changelog Action
-    runs-on: ubuntu-latest
-    steps:
-      - uses: UCD-SERG/changelog-check-action@v2
-        with:
-          changelog: NEWS.md
+  check:
+    uses: d-morrison/gha/.github/workflows/check-news.yml@v1


### PR DESCRIPTION
Pilot migration to the new central reusable-workflows repo **[d-morrison/gha](https://github.com/d-morrison/gha)** (`@v1`).

## What changed
- `news.yaml` is now a caller stub invoking `d-morrison/gha/.github/workflows/check-news.yml@v1`, which wraps `UCD-SERG/changelog-check-action@v2` exactly as before. Behavior (and the `no-changelog` label escape hatch handled by the action) is unchanged.

## Why
Consolidating duplicated GitHub Actions into a single source of truth. `news.yaml` is byte-identical across ~11 R-package repos, so it's an ideal first candidate. This PR (UCD-SERG owner) also proves the public reusable workflow is callable cross-owner from `d-morrison/gha`.

## Verification
This PR's `pull_request` event triggers the reusable check-news workflow. Validated end-to-end alongside `d-morrison/psw#29` and `ucdavis/dl#5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)